### PR TITLE
added input for mix.exs path in live view

### DIFF
--- a/apps/spider_sense_web/lib/spider_sense_web/live/dgraph_live.ex
+++ b/apps/spider_sense_web/lib/spider_sense_web/live/dgraph_live.ex
@@ -4,6 +4,14 @@ defmodule SpiderSenseWeb.DGraphLive do
   def render(assigns) do
     ~L"""
     <h3>Live value: <%= @counter %></h3>
+    <form phx-submit="load_graph">
+      <label for="path">Path to the <code>mix.exs</code> file</label>
+      <input type="text" name="path"></input>
+      <button type="submit">Load Graph</button>
+    </form>
+    <%= if @loading do %>
+      <div>Loading...</div>
+    <% end %>
     <div id="dgraph" data-chart="<%= Jason.encode!(@chart_data) %>">
       <svg width="600" height="600"></svg>
     </div>
@@ -29,9 +37,18 @@ defmodule SpiderSenseWeb.DGraphLive do
     """
   end
 
+  @impl Phoenix.LiveView
+  def handle_event("load_graph", %{"path" => path}, socket) do
+    # kick off the graph loading
+    {:noreply,
+      socket
+      |> assign(:loading, true)}
+  end
+
   def mount(_params, _session, socket) do
     {:ok,
       socket
+      |> assign(:loading, false)
       |> assign(:counter, 0)
       |> assign(:chart_data, %{
         nodes: [


### PR DESCRIPTION
Added a simple input with a handler to the LiveView which will allow us to receive the path to the `mix.exs` file from the user and kick off the DExplorer Tracer